### PR TITLE
ZapToken Class & ZapToken Test Refactor

### DIFF
--- a/ZapToken/zaptoken.ts
+++ b/ZapToken/zaptoken.ts
@@ -1,7 +1,5 @@
 import { BaseContract } from '../BaseContract/basecontract';
 
-import { Util } from './tokenutils';
-
 import {
     TransferType,
     address,
@@ -11,12 +9,10 @@ import {
     NumType
 } from '../Types/types';
 
-import { toHex } from 'web3-utils';
-
-
 /**
  * @class
- * Provides Represents an interface to the Zap Token ERC20 contract. Enables token transfers, balance lookups, and approvals.
+ * Provides Represents an interface to the Zap Token ERC20 contract. 
+ * Enables token transfers, balance lookups, and approvals.
  */
 
 export class ZapToken extends BaseContract {
@@ -25,15 +21,15 @@ export class ZapToken extends BaseContract {
      * @constructor
      * @param obj
      * @param {string} n.artifactsDir - Directory where contract ABIs are located
-     * @param {number|string} n.networkId - Select which network the contract is located on (mainnet, testnet, private)
+     * @param {number|string} n.networkId - Select which network the contract is located on (mainnet, 
+     * testnet, private)
      * @param {any} n.networkProvider - Ethereum network provider (e.g. Infura)
-     * @example new ZapToken({networkId : 42, networkProvider : web3})
+     * @example new ZapToken({networkId : 42, networkProvider : http://localhost:8545})
      */
 
     constructor(obj?: NetworkProviderOptions) {
         super(Object.assign(obj || {}, { artifactName: 'ZAP_TOKEN' }));
     }
-
 
     /**
      * Get the Zap Token balance of a given address.
@@ -52,8 +48,6 @@ export class ZapToken extends BaseContract {
      * @param {TransferType} t. {to, amount, from,gas=Util.DEFAULT_GAS}
      * @param {address} t.to - Address of the recipient
      * @param {number} t.amount - Amount of Zap to transfer (wei)
-     * @param {address} t.from - Address of the sender
-     * @param {number} t.gas - Sets the gas limit for this transaction (optional)
      * @param {Function} cb - Callback for transactionHash event
      * @returns {Promise<txid>} Returns a Promise that will eventually resolve into a transaction hash
      */
@@ -73,8 +67,6 @@ export class ZapToken extends BaseContract {
      * @param {TransferType} t. {to, amount, from,gas=Util.DEFAULT_GAS}
      * @param {address} t.to - Address of the recipient
      * @param {number} t.amount - Amount of Zap to allocate (wei)
-     * @param {address} t.from - Address of the sender (must be owner of the Zap contract)
-     * @param {number} t.gas - Sets the gas limit for this transaction (optional)
      * @param {Function} cb - Callback for transactionHash event
      * @returns {Promise<txid>} Returns a Promise that will eventually resolve into a transaction hash
      */
@@ -95,8 +87,6 @@ export class ZapToken extends BaseContract {
      * @param {TransferType} t. {to, amount, from, gas=Util.DEFAULT_GAS}
      * @param {address} t.to - Address of the recipient
      * @param {number} t.amount - Amount of Zap to approve (wei)
-     * @param {address} t.from - Address of the sender
-     * @param {number} t.gas - Sets the gas limit for this transaction (optional)
      * @param {Function} cb - Callback for transactionHash event
      * @returns {Promise<txid>} Returns a Promise that will eventually resolve into a transaction hash
      */

--- a/ZapToken/zaptoken.ts
+++ b/ZapToken/zaptoken.ts
@@ -57,9 +57,9 @@ export class ZapToken extends BaseContract {
      * @param {Function} cb - Callback for transactionHash event
      * @returns {Promise<txid>} Returns a Promise that will eventually resolve into a transaction hash
      */
-    async send({ to, amount, from, gasPrice, gas = Util.DEFAULT_GAS }: TransferType, cb?: TransactionCallback): Promise<txid> {
-        amount = toHex(amount);
-        const promiEvent = this.contract.transfer(to, amount).send({ from, gas, gasPrice });
+    async send({ to, amount }: TransferType, cb?: TransactionCallback): Promise<txid> {
+
+        const promiEvent = this.contract.transfer(to, amount)
         if (cb) {
             promiEvent.on('transactionHash', (transactionHash: string) => cb(null, transactionHash));
             promiEvent.on('error', (error: any) => cb(error));
@@ -100,10 +100,9 @@ export class ZapToken extends BaseContract {
      * @param {Function} cb - Callback for transactionHash event
      * @returns {Promise<txid>} Returns a Promise that will eventually resolve into a transaction hash
      */
-    async approve({ to, amount, from, gasPrice, gas = Util.DEFAULT_GAS }: TransferType, cb?: TransactionCallback): Promise<txid> {
-        amount = toHex(amount);
+    async approve({ to, amount }: TransferType, cb?: TransactionCallback): Promise<txid> {
 
-        const _success = this.contract.approve(to, amount).send({ from, gas, gasPrice });
+        const _success = this.contract.approve(to, amount);
 
         if (cb) {
             _success.on('transactionHash', (transactionHash: string) => cb(null, transactionHash));

--- a/ZapToken/zaptoken.ts
+++ b/ZapToken/zaptoken.ts
@@ -42,7 +42,9 @@ export class ZapToken extends BaseContract {
      */
     async balanceOf(address: address): Promise<string | number> {
 
-        return await this.contract.balanceOf(address);
+        const balance = await this.contract.balanceOf(address);
+
+        return parseInt(balance);
     }
 
     /**

--- a/ZapToken/zaptoken.ts
+++ b/ZapToken/zaptoken.ts
@@ -78,9 +78,9 @@ export class ZapToken extends BaseContract {
      * @param {Function} cb - Callback for transactionHash event
      * @returns {Promise<txid>} Returns a Promise that will eventually resolve into a transaction hash
      */
-    async allocate({ to, amount, from, gasPrice, gas = Util.DEFAULT_GAS }: TransferType, cb?: TransactionCallback): Promise<txid> {
-        amount = toHex(amount);
-        const promiEvent = this.contract.allocate(to, amount).send({ from, gas, gasPrice });
+    async allocate({ to, amount }: TransferType, cb?: TransactionCallback): Promise<txid> {
+
+        const promiEvent = this.contract.allocate(to, amount);
 
         if (cb) {
             promiEvent.on('transactionHash', (transactionHash: string) => cb(null, transactionHash));

--- a/test/registrytest.ts
+++ b/test/registrytest.ts
@@ -8,6 +8,7 @@ import {
     HardhatProvider
 }
     from '../Utils/utils';
+import { AnyARecord } from 'node:dns';
 
 const expect = require('chai').expect;
 
@@ -15,10 +16,8 @@ describe('Registry Test', () => {
 
     let hardhatHttpProvider: any;
     let hardhatAccounts: any;
-    let signerOne: any
-    let signerTwo: any
 
-    let account: Array<string> = [],
+    let signers: Array<any> = [],
         registryWrapper: any,
         testProvider = testZapProvider,
         options: any = {
@@ -32,9 +31,10 @@ describe('Registry Test', () => {
 
         hardhatAccounts = await hardhatHttpProvider.listAccounts();
 
-        signerOne = await hardhatHttpProvider.getSigner(hardhatAccounts[0]);
+        for (let i = 0; i < hardhatAccounts.length; i++) {
 
-        signerTwo = await hardhatHttpProvider.getSigner(hardhatAccounts[1]);
+            signers.push(await hardhatHttpProvider.getSigner(hardhatAccounts[i]));
+        }
 
     });
 
@@ -94,23 +94,23 @@ describe('Registry Test', () => {
 
             expect(testProvider.title).to.equal(ethers.utils.parseBytes32String(args.title));
 
-            expect(args.provider).to.equal(signerOne._address);
+            expect(args.provider).to.equal(signers[0]._address);
 
-            const title = await registryWrapper.getProviderTitle(signerOne._address);
+            const title = await registryWrapper.getProviderTitle(signers[0]._address);
 
             expect(title).to.be.equal(testProvider.title);
 
-            const pubkey = await registryWrapper.getProviderPublicKey(signerOne._address);
+            const pubkey = await registryWrapper.getProviderPublicKey(signers[0]._address);
 
             expect(pubkey).to.be.equal(testProvider.pubkey);
 
         } catch (err) {
 
-            const initStatus = await registryWrapper.isProviderInitiated(signerOne._address);
+            const initStatus = await registryWrapper.isProviderInitiated(signers[0]._address);
 
             if (initStatus === true) {
 
-                console.log(signerOne._address + ': ' + 'Is already initiated as a provider');
+                console.log(signers[0]._address + ': ' + 'Is already initiated as a provider');
             }
             else {
 
@@ -147,7 +147,7 @@ describe('Registry Test', () => {
 
             expect(args.broker).to.equal(testProvider.broker);
 
-            expect(args.provider).to.equal(signerOne._address);
+            expect(args.provider).to.equal(signers[0]._address);
 
             const getTxCurve = args.curve.map((num: any) => parseInt(num));
 
@@ -159,7 +159,7 @@ describe('Registry Test', () => {
 
         } catch (err: any) {
 
-            console.log(signerOne._address + ': ' + 'Curve is already initiated');
+            console.log(signers[0]._address + ': ' + 'Curve is already initiated');
         }
 
     });
@@ -175,7 +175,7 @@ describe('Registry Test', () => {
 
                 expect(setTitle).to.be.ok;
 
-                const newTitle = await registryWrapper.getProviderTitle(signerOne._address);
+                const newTitle = await registryWrapper.getProviderTitle(signers[0]._address);
 
                 expect(newTitle).to.equal(title);
             })
@@ -192,7 +192,7 @@ describe('Registry Test', () => {
             await registryWrapper.initiateProviderCurve({
                 endpoint: testProvider.endpoints[1],
                 term: testProvider.curve.values,
-                broker: signerTwo._address,
+                broker: signers[1]._address,
             })
                 .then((initCurveTwoTx: Object) => {
 
@@ -206,7 +206,7 @@ describe('Registry Test', () => {
 
         } catch (err) {
 
-            console.log(signerTwo._address + ': ' + 'Provider and Curve is already initiated');
+            console.log(signers[1]._address + ': ' + 'Provider and Curve is already initiated');
         }
 
     });
@@ -214,7 +214,7 @@ describe('Registry Test', () => {
     it('Should get the provider curve', async () => {
 
         await registryWrapper.getProviderCurve(
-            signerOne._address,
+            signers[1]._address,
             testProvider.endpoints[0]
         )
             .then((getCurve: Array<number>) => {
@@ -232,7 +232,7 @@ describe('Registry Test', () => {
     it('Should get endpoint broker', async () => {
 
         await registryWrapper.getEndpointBroker(
-            signerOne._address,
+            signers[1]._address,
             testProvider.endpoints[0]
         )
             .then((getBroker: String) => {
@@ -264,7 +264,7 @@ describe('Registry Test', () => {
     it('Should get the endpoint params in zap registry contract', async () => {
 
         await registryWrapper.getEndpointParams({
-            provider: signerOne._address,
+            provider: signers[1]._address,
             endpoint: testProvider.endpoints[0]
         })
             .then((endpointParams: Array<string>) => {
@@ -312,7 +312,7 @@ describe('Registry Test', () => {
     it('Should get the markdown url from the first endpoint param', async () => {
 
         await registryWrapper.getProviderParam(
-            signerOne._address,
+            signers[0]._address,
             testProvider.endpoint_params[0]
         )
             .then((markdownParam: String) => {
@@ -326,7 +326,7 @@ describe('Registry Test', () => {
     it('Should get the json url from the second endpoint param', async () => {
 
         await registryWrapper.getProviderParam(
-            signerOne._address,
+            signers[0]._address,
             testProvider.endpoint_params[1]
         )
             .then((jsonParam: String) => {
@@ -340,7 +340,7 @@ describe('Registry Test', () => {
 
     it('Should get all provider params', async () => {
 
-        await registryWrapper.getAllProviderParams(signerOne._address)
+        await registryWrapper.getAllProviderParams(signers[0]._address)
 
             .then((getProviderParams: Array<string>) => {
 
@@ -403,7 +403,7 @@ describe('Registry Test', () => {
     it('Should check if the endpoint and corresponding curve is set', async () => {
 
         await registryWrapper.isEndpointSet(
-            signerOne._address,
+            signers[0]._address,
             testProvider.endpoints[0]
         )
             .then((unset: Boolean) => {
@@ -450,7 +450,7 @@ describe('Registry Test', () => {
 
     it('Should have an empty array of endpoints after clearing', async () => {
 
-        await registryWrapper.getProviderEndpoints(signerOne._address)
+        await registryWrapper.getProviderEndpoints(signers[0]._address)
 
             .then((getEndpoints: Array<string>) => {
 

--- a/test/zaptokentest.ts
+++ b/test/zaptokentest.ts
@@ -42,6 +42,12 @@ describe('ZapToken Test', () => {
 
     });
 
+    after(() => {
+
+        console.log('Done running ZapToken tests');
+
+    });
+
     it('Should initiate wrapper', async () => {
 
         zapTokenWrapper = new ZapToken(options)

--- a/test/zaptokentest.ts
+++ b/test/zaptokentest.ts
@@ -15,10 +15,8 @@ describe('ZapToken Test', () => {
 
     let hardhatHttpProvider: any;
     let hardhatAccounts: any;
-    let signerOne: any
-    let signerTwo: any
-    let signerThree: any
-
+    let signerOne: any;
+    let signerTwo: any;
 
     let accounts: Array<string> = [],
         HardhatServer: any,
@@ -41,8 +39,6 @@ describe('ZapToken Test', () => {
         signerOne = await hardhatHttpProvider.getSigner(hardhatAccounts[0]);
 
         signerTwo = await hardhatHttpProvider.getSigner(hardhatAccounts[1]);
-
-        signerThree = await hardhatHttpProvider.getSigner(hardhatAccounts[2]);
 
     });
 
@@ -115,6 +111,44 @@ describe('ZapToken Test', () => {
                 expect(allocateTx).to.be.ok;
                 expect(afterAllocation).to.be.equal(allocateAmount + beforeAllocation);
 
+            })
+            .catch((err: Object) => {
+
+                return err;
+            })
+    });
+
+    it('Should make transfer to another account', async () => {
+
+        const beforeTransfer = await zapTokenWrapper.balanceOf(signerTwo._address);
+
+        await zapTokenWrapper.send({
+            to: signerTwo,
+            amount: allocateAmount,
+        })
+            .then(async (transferTx: Object) => {
+
+                const afterTransfer = await zapTokenWrapper.balanceOf(signerTwo._address);
+
+                expect(transferTx).to.be.ok;
+                expect(afterTransfer).to.be.ok;
+                expect(afterTransfer).to.be.equal(allocateAmount + beforeTransfer);
+
+            })
+            .catch((err: Object) => {
+
+                return err;
+            })
+    });
+
+    it('Should approve to transfer from one to the another account', async () => {
+
+        await zapTokenWrapper.approve({
+            to: signerTwo._address,
+            amount: allocateAmount,
+        })
+            .then((approveTx: Object) => {
+                expect(approveTx).to.be.ok;
             })
             .catch((err: Object) => {
 

--- a/test/zaptokentest.ts
+++ b/test/zaptokentest.ts
@@ -15,10 +15,8 @@ describe('ZapToken Test', () => {
 
     let hardhatHttpProvider: any;
     let hardhatAccounts: any;
-    let signerOne: any;
-    let signerTwo: any;
 
-    let accounts: Array<string> = [],
+    let signers: Array<any> = [],
         HardhatServer: any,
         zapTokenWrapper: any,
         testProvider = testZapProvider,
@@ -36,9 +34,10 @@ describe('ZapToken Test', () => {
 
         hardhatAccounts = await hardhatHttpProvider.listAccounts();
 
-        signerOne = await hardhatHttpProvider.getSigner(hardhatAccounts[0]);
+        for (let i = 0; i < hardhatAccounts.length; i++) {
 
-        signerTwo = await hardhatHttpProvider.getSigner(hardhatAccounts[1]);
+            signers.push(await hardhatHttpProvider.getSigner(hardhatAccounts[i]));
+        }
 
     });
 
@@ -77,7 +76,7 @@ describe('ZapToken Test', () => {
 
             .then((owner: String) => {
 
-                expect(owner).to.be.equal(signerOne._address);
+                expect(owner).to.be.equal(signers[0]._address);
 
             })
             .catch((err: Object) => {
@@ -88,7 +87,7 @@ describe('ZapToken Test', () => {
 
     it('Should get balance of zapToken from wrapper', async () => {
 
-        await zapTokenWrapper.balanceOf(signerOne._address)
+        await zapTokenWrapper.balanceOf(signers[0]._address)
 
             .then((balance: Number) => {
 
@@ -103,15 +102,15 @@ describe('ZapToken Test', () => {
 
     it('Should update balance, and get updated balance of zap token', async () => {
 
-        const beforeAllocation = await zapTokenWrapper.balanceOf(signerTwo._address);
+        const beforeAllocation = await zapTokenWrapper.balanceOf(signers[1]._address);
 
         await zapTokenWrapper.allocate({
-            to: signerTwo._address,
+            to: signers[1]._address,
             amount: allocateAmount
         })
             .then(async (allocateTx: Object) => {
 
-                const afterAllocation = await zapTokenWrapper.balanceOf(signerTwo._address);
+                const afterAllocation = await zapTokenWrapper.balanceOf(signers[1]._address);
                 expect(beforeAllocation).to.be.ok;
                 expect(afterAllocation).to.be.ok;
                 expect(allocateTx).to.be.ok;
@@ -126,15 +125,15 @@ describe('ZapToken Test', () => {
 
     it('Should make transfer to another account', async () => {
 
-        const beforeTransfer = await zapTokenWrapper.balanceOf(signerTwo._address);
+        const beforeTransfer = await zapTokenWrapper.balanceOf(signers[1]._address);
 
         await zapTokenWrapper.send({
-            to: signerTwo,
+            to: signers[1]._address,
             amount: allocateAmount,
         })
             .then(async (transferTx: Object) => {
 
-                const afterTransfer = await zapTokenWrapper.balanceOf(signerTwo._address);
+                const afterTransfer = await zapTokenWrapper.balanceOf(signers[1]._address);
 
                 expect(transferTx).to.be.ok;
                 expect(afterTransfer).to.be.ok;
@@ -150,7 +149,7 @@ describe('ZapToken Test', () => {
     it('Should approve to transfer from one to the another account', async () => {
 
         await zapTokenWrapper.approve({
-            to: signerTwo._address,
+            to: signers[1]._address,
             amount: allocateAmount,
         })
             .then((approveTx: Object) => {

--- a/test/zaptokentest.ts
+++ b/test/zaptokentest.ts
@@ -72,6 +72,7 @@ describe('ZapToken Test', () => {
     it('Should get zapToken owner', async () => {
 
         await zapTokenWrapper.getContractOwner()
+
             .then((owner: String) => {
 
                 expect(owner).to.be.equal(signerOne._address);
@@ -83,12 +84,21 @@ describe('ZapToken Test', () => {
             })
     });
 
-    // it('Should get balance of zapToken from wrapper', async () => {
+    it('Should get balance of zapToken from wrapper', async () => {
 
-    //     const balance = await zapTokenWrapper.balanceOf(signerOne._address);
+        await zapTokenWrapper.balanceOf(signerOne._address)
 
-    //     expect(balance).to.be.ok;
-    // });
+            .then((balance: Number) => {
+
+                expect(balance).to.be.ok;
+                expect(balance).to.be.gt(0);
+            })
+            .catch((err: Object) => {
+
+                return err;
+            })
+
+    });
 
 
 });

--- a/test/zaptokentest.ts
+++ b/test/zaptokentest.ts
@@ -65,27 +65,30 @@ describe('ZapToken Test', () => {
             coordinator: zapTokenWrapper.coordinator.address
         });
 
-        //     zapTokenOwner = await zapTokenWrapper.getContractOwner();
-
-        //     expect(zapTokenWrapper).to.be.ok;
-
-        // });
-
-        // it('Should get zapToken owner', async () => {
-
-        //     const owner = await zapTokenWrapper.getContractOwner();
-
-        //     expect(owner).to.be.equal(signerOne._address);
-
-        // });
-
-        // it('Should get balance of zapToken from wrapper', async () => {
-
-        //     const balance = await zapTokenWrapper.balanceOf(signerOne._address);
-
-        //     expect(balance).to.be.ok;
-        // });
-
+        expect(zapTokenWrapper).to.be.ok;
 
     });
-})
+
+    it('Should get zapToken owner', async () => {
+
+        await zapTokenWrapper.getContractOwner()
+            .then((owner: String) => {
+
+                expect(owner).to.be.equal(signerOne._address);
+
+            })
+            .catch((err: Object) => {
+
+                return err;
+            })
+    });
+
+    // it('Should get balance of zapToken from wrapper', async () => {
+
+    //     const balance = await zapTokenWrapper.balanceOf(signerOne._address);
+
+    //     expect(balance).to.be.ok;
+    // });
+
+
+});

--- a/test/zaptokentest.ts
+++ b/test/zaptokentest.ts
@@ -71,20 +71,20 @@ describe('ZapToken Test', () => {
 
     // });
 
-    it('Should get zapToken owner', async () => {
+    // it('Should get zapToken owner', async () => {
 
-        const owner = await zapTokenWrapper.getContractOwner();
+    //     const owner = await zapTokenWrapper.getContractOwner();
 
-        expect(owner).to.be.equal(signerOne._address);
+    //     expect(owner).to.be.equal(signerOne._address);
 
-    });
+    // });
 
-    it('Should get balance of zapToken from wrapper', async () => {
+    // it('Should get balance of zapToken from wrapper', async () => {
 
-        const balance = await zapTokenWrapper.balanceOf(signerOne._address);
+    //     const balance = await zapTokenWrapper.balanceOf(signerOne._address);
 
-        expect(balance).to.be.ok;
-    });
+    //     expect(balance).to.be.ok;
+    // });
 
 
 });

--- a/test/zaptokentest.ts
+++ b/test/zaptokentest.ts
@@ -44,7 +44,6 @@ describe('ZapToken Test', () => {
 
         signerThree = await hardhatHttpProvider.getSigner(hardhatAccounts[2]);
 
-
     });
 
     it('Should initiate wrapper', async () => {
@@ -53,39 +52,40 @@ describe('ZapToken Test', () => {
 
         zapTokenOwner = await zapTokenWrapper.getContractOwner();
 
+        expect(zapTokenOwner).to.be.ok;
         expect(zapTokenWrapper).to.be.ok;
 
     });
 
-    // it('Should initiate wrapper with coordinator ', async () => {
+    it('Should initiate wrapper with coordinator ', async () => {
 
-    //     zapTokenWrapper = new ZapToken({
-    //         networkId: HardhatServerOptions.network_id,
-    //         networkProvider: HardhatProvider,
-    //         coordinator: zapTokenWrapper.coordinator.address
-    //     });
+        zapTokenWrapper = new ZapToken({
+            networkId: HardhatServerOptions.network_id,
+            networkProvider: HardhatProvider,
+            coordinator: zapTokenWrapper.coordinator.address
+        });
 
-    //     zapTokenOwner = await zapTokenWrapper.getContractOwner();
+        //     zapTokenOwner = await zapTokenWrapper.getContractOwner();
 
-    //     expect(zapTokenWrapper).to.be.ok;
+        //     expect(zapTokenWrapper).to.be.ok;
 
-    // });
+        // });
 
-    // it('Should get zapToken owner', async () => {
+        // it('Should get zapToken owner', async () => {
 
-    //     const owner = await zapTokenWrapper.getContractOwner();
+        //     const owner = await zapTokenWrapper.getContractOwner();
 
-    //     expect(owner).to.be.equal(signerOne._address);
+        //     expect(owner).to.be.equal(signerOne._address);
 
-    // });
+        // });
 
-    // it('Should get balance of zapToken from wrapper', async () => {
+        // it('Should get balance of zapToken from wrapper', async () => {
 
-    //     const balance = await zapTokenWrapper.balanceOf(signerOne._address);
+        //     const balance = await zapTokenWrapper.balanceOf(signerOne._address);
 
-    //     expect(balance).to.be.ok;
-    // });
+        //     expect(balance).to.be.ok;
+        // });
 
 
-});
-
+    });
+})

--- a/test/zaptokentest.ts
+++ b/test/zaptokentest.ts
@@ -97,8 +97,29 @@ describe('ZapToken Test', () => {
 
                 return err;
             })
-
     });
 
+    it('Should update balance, and get updated balance of zap token', async () => {
+
+        const beforeAllocation = await zapTokenWrapper.balanceOf(signerTwo._address);
+
+        await zapTokenWrapper.allocate({
+            to: signerTwo._address,
+            amount: allocateAmount
+        })
+            .then(async (allocateTx: Object) => {
+
+                const afterAllocation = await zapTokenWrapper.balanceOf(signerTwo._address);
+                expect(beforeAllocation).to.be.ok;
+                expect(afterAllocation).to.be.ok;
+                expect(allocateTx).to.be.ok;
+                expect(afterAllocation).to.be.equal(allocateAmount + beforeAllocation);
+
+            })
+            .catch((err: Object) => {
+
+                return err;
+            })
+    });
 
 });


### PR DESCRIPTION
## Summary

Closes #18 

## Implementation

-  Converted the ZapToken class from Web3.js to Ethers.js
- The ZapToken class can be instantiated with Ethers.js
- Converted the ZapToken tests to use Ethers.js and reference the ZapToken functions to pass after running the Hardhat node and npm test
- Changed how the Hardhat signers were being stored and accessed for the ZapToken and Registry tests

## Files

```ZapToken\zaptoken.ts ```
```test\zaptokentest.ts ```
```test\registrytest.ts ```

## Visual Preview

While the Hardhat node is running and the contracts are deployed the tests will start with npm test
![Screenshot (217)](https://user-images.githubusercontent.com/42893948/111203108-f661e280-859a-11eb-985f-fa58c9f74da9.png)

