### PR TITLE
Bugfix Registry & ZapToken Tests

### DIFF
--- a/ZapToken/zaptoken.ts
+++ b/ZapToken/zaptoken.ts
@@ -1,7 +1,5 @@
 import { BaseContract } from '../BaseContract/basecontract';
 
-import { Util } from './tokenutils';
-
 import {
     TransferType,
     address,
@@ -11,12 +9,10 @@ import {
     NumType
 } from '../Types/types';
 
-import { toHex } from 'web3-utils';
-
-
 /**
  * @class
- * Provides Represents an interface to the Zap Token ERC20 contract. Enables token transfers, balance lookups, and approvals.
+ * Provides Represents an interface to the Zap Token ERC20 contract. 
+ * Enables token transfers, balance lookups, and approvals.
  */
 
 export class ZapToken extends BaseContract {
@@ -25,15 +21,15 @@ export class ZapToken extends BaseContract {
      * @constructor
      * @param obj
      * @param {string} n.artifactsDir - Directory where contract ABIs are located
-     * @param {number|string} n.networkId - Select which network the contract is located on (mainnet, testnet, private)
+     * @param {number|string} n.networkId - Select which network the contract is located on (mainnet, 
+     * testnet, private)
      * @param {any} n.networkProvider - Ethereum network provider (e.g. Infura)
-     * @example new ZapToken({networkId : 42, networkProvider : web3})
+     * @example new ZapToken({networkId : 42, networkProvider : http://localhost:8545})
      */
 
     constructor(obj?: NetworkProviderOptions) {
         super(Object.assign(obj || {}, { artifactName: 'ZAP_TOKEN' }));
     }
-
 
     /**
      * Get the Zap Token balance of a given address.
@@ -52,8 +48,6 @@ export class ZapToken extends BaseContract {
      * @param {TransferType} t. {to, amount, from,gas=Util.DEFAULT_GAS}
      * @param {address} t.to - Address of the recipient
      * @param {number} t.amount - Amount of Zap to transfer (wei)
-     * @param {address} t.from - Address of the sender
-     * @param {number} t.gas - Sets the gas limit for this transaction (optional)
      * @param {Function} cb - Callback for transactionHash event
      * @returns {Promise<txid>} Returns a Promise that will eventually resolve into a transaction hash
      */
@@ -73,8 +67,6 @@ export class ZapToken extends BaseContract {
      * @param {TransferType} t. {to, amount, from,gas=Util.DEFAULT_GAS}
      * @param {address} t.to - Address of the recipient
      * @param {number} t.amount - Amount of Zap to allocate (wei)
-     * @param {address} t.from - Address of the sender (must be owner of the Zap contract)
-     * @param {number} t.gas - Sets the gas limit for this transaction (optional)
      * @param {Function} cb - Callback for transactionHash event
      * @returns {Promise<txid>} Returns a Promise that will eventually resolve into a transaction hash
      */
@@ -95,8 +87,6 @@ export class ZapToken extends BaseContract {
      * @param {TransferType} t. {to, amount, from, gas=Util.DEFAULT_GAS}
      * @param {address} t.to - Address of the recipient
      * @param {number} t.amount - Amount of Zap to approve (wei)
-     * @param {address} t.from - Address of the sender
-     * @param {number} t.gas - Sets the gas limit for this transaction (optional)
      * @param {Function} cb - Callback for transactionHash event
      * @returns {Promise<txid>} Returns a Promise that will eventually resolve into a transaction hash
      */

--- a/ZapToken/zaptoken.ts
+++ b/ZapToken/zaptoken.ts
@@ -57,9 +57,9 @@ export class ZapToken extends BaseContract {
      * @param {Function} cb - Callback for transactionHash event
      * @returns {Promise<txid>} Returns a Promise that will eventually resolve into a transaction hash
      */
-    async send({ to, amount, from, gasPrice, gas = Util.DEFAULT_GAS }: TransferType, cb?: TransactionCallback): Promise<txid> {
-        amount = toHex(amount);
-        const promiEvent = this.contract.transfer(to, amount).send({ from, gas, gasPrice });
+    async send({ to, amount }: TransferType, cb?: TransactionCallback): Promise<txid> {
+
+        const promiEvent = this.contract.transfer(to, amount)
         if (cb) {
             promiEvent.on('transactionHash', (transactionHash: string) => cb(null, transactionHash));
             promiEvent.on('error', (error: any) => cb(error));
@@ -100,10 +100,9 @@ export class ZapToken extends BaseContract {
      * @param {Function} cb - Callback for transactionHash event
      * @returns {Promise<txid>} Returns a Promise that will eventually resolve into a transaction hash
      */
-    async approve({ to, amount, from, gasPrice, gas = Util.DEFAULT_GAS }: TransferType, cb?: TransactionCallback): Promise<txid> {
-        amount = toHex(amount);
+    async approve({ to, amount }: TransferType, cb?: TransactionCallback): Promise<txid> {
 
-        const _success = this.contract.approve(to, amount).send({ from, gas, gasPrice });
+        const _success = this.contract.approve(to, amount);
 
         if (cb) {
             _success.on('transactionHash', (transactionHash: string) => cb(null, transactionHash));

--- a/ZapToken/zaptoken.ts
+++ b/ZapToken/zaptoken.ts
@@ -42,7 +42,9 @@ export class ZapToken extends BaseContract {
      */
     async balanceOf(address: address): Promise<string | number> {
 
-        return await this.contract.balanceOf(address);
+        const balance = await this.contract.balanceOf(address);
+
+        return parseInt(balance);
     }
 
     /**

--- a/ZapToken/zaptoken.ts
+++ b/ZapToken/zaptoken.ts
@@ -78,9 +78,9 @@ export class ZapToken extends BaseContract {
      * @param {Function} cb - Callback for transactionHash event
      * @returns {Promise<txid>} Returns a Promise that will eventually resolve into a transaction hash
      */
-    async allocate({ to, amount, from, gasPrice, gas = Util.DEFAULT_GAS }: TransferType, cb?: TransactionCallback): Promise<txid> {
-        amount = toHex(amount);
-        const promiEvent = this.contract.allocate(to, amount).send({ from, gas, gasPrice });
+    async allocate({ to, amount }: TransferType, cb?: TransactionCallback): Promise<txid> {
+
+        const promiEvent = this.contract.allocate(to, amount);
 
         if (cb) {
             promiEvent.on('transactionHash', (transactionHash: string) => cb(null, transactionHash));

--- a/test/registrytest.ts
+++ b/test/registrytest.ts
@@ -8,6 +8,7 @@ import {
     HardhatProvider
 }
     from '../Utils/utils';
+import { AnyARecord } from 'node:dns';
 
 const expect = require('chai').expect;
 
@@ -15,10 +16,8 @@ describe('Registry Test', () => {
 
     let hardhatHttpProvider: any;
     let hardhatAccounts: any;
-    let signerOne: any
-    let signerTwo: any
 
-    let account: Array<string> = [],
+    let signers: Array<any> = [],
         registryWrapper: any,
         testProvider = testZapProvider,
         options: any = {
@@ -32,9 +31,10 @@ describe('Registry Test', () => {
 
         hardhatAccounts = await hardhatHttpProvider.listAccounts();
 
-        signerOne = await hardhatHttpProvider.getSigner(hardhatAccounts[0]);
+        for (let i = 0; i < hardhatAccounts.length; i++) {
 
-        signerTwo = await hardhatHttpProvider.getSigner(hardhatAccounts[1]);
+            signers.push(await hardhatHttpProvider.getSigner(hardhatAccounts[i]));
+        }
 
     });
 
@@ -94,23 +94,23 @@ describe('Registry Test', () => {
 
             expect(testProvider.title).to.equal(ethers.utils.parseBytes32String(args.title));
 
-            expect(args.provider).to.equal(signerOne._address);
+            expect(args.provider).to.equal(signers[0]._address);
 
-            const title = await registryWrapper.getProviderTitle(signerOne._address);
+            const title = await registryWrapper.getProviderTitle(signers[0]._address);
 
             expect(title).to.be.equal(testProvider.title);
 
-            const pubkey = await registryWrapper.getProviderPublicKey(signerOne._address);
+            const pubkey = await registryWrapper.getProviderPublicKey(signers[0]._address);
 
             expect(pubkey).to.be.equal(testProvider.pubkey);
 
         } catch (err) {
 
-            const initStatus = await registryWrapper.isProviderInitiated(signerOne._address);
+            const initStatus = await registryWrapper.isProviderInitiated(signers[0]._address);
 
             if (initStatus === true) {
 
-                console.log(signerOne._address + ': ' + 'Is already initiated as a provider');
+                console.log(signers[0]._address + ': ' + 'Is already initiated as a provider');
             }
             else {
 
@@ -147,7 +147,7 @@ describe('Registry Test', () => {
 
             expect(args.broker).to.equal(testProvider.broker);
 
-            expect(args.provider).to.equal(signerOne._address);
+            expect(args.provider).to.equal(signers[0]._address);
 
             const getTxCurve = args.curve.map((num: any) => parseInt(num));
 
@@ -159,7 +159,7 @@ describe('Registry Test', () => {
 
         } catch (err: any) {
 
-            console.log(signerOne._address + ': ' + 'Curve is already initiated');
+            console.log(signers[0]._address + ': ' + 'Curve is already initiated');
         }
 
     });
@@ -175,7 +175,7 @@ describe('Registry Test', () => {
 
                 expect(setTitle).to.be.ok;
 
-                const newTitle = await registryWrapper.getProviderTitle(signerOne._address);
+                const newTitle = await registryWrapper.getProviderTitle(signers[0]._address);
 
                 expect(newTitle).to.equal(title);
             })
@@ -192,7 +192,7 @@ describe('Registry Test', () => {
             await registryWrapper.initiateProviderCurve({
                 endpoint: testProvider.endpoints[1],
                 term: testProvider.curve.values,
-                broker: signerTwo._address,
+                broker: signers[1]._address,
             })
                 .then((initCurveTwoTx: Object) => {
 
@@ -206,7 +206,7 @@ describe('Registry Test', () => {
 
         } catch (err) {
 
-            console.log(signerTwo._address + ': ' + 'Provider and Curve is already initiated');
+            console.log(signers[1]._address + ': ' + 'Provider and Curve is already initiated');
         }
 
     });
@@ -214,7 +214,7 @@ describe('Registry Test', () => {
     it('Should get the provider curve', async () => {
 
         await registryWrapper.getProviderCurve(
-            signerOne._address,
+            signers[1]._address,
             testProvider.endpoints[0]
         )
             .then((getCurve: Array<number>) => {
@@ -232,7 +232,7 @@ describe('Registry Test', () => {
     it('Should get endpoint broker', async () => {
 
         await registryWrapper.getEndpointBroker(
-            signerOne._address,
+            signers[1]._address,
             testProvider.endpoints[0]
         )
             .then((getBroker: String) => {
@@ -264,7 +264,7 @@ describe('Registry Test', () => {
     it('Should get the endpoint params in zap registry contract', async () => {
 
         await registryWrapper.getEndpointParams({
-            provider: signerOne._address,
+            provider: signers[1]._address,
             endpoint: testProvider.endpoints[0]
         })
             .then((endpointParams: Array<string>) => {
@@ -312,7 +312,7 @@ describe('Registry Test', () => {
     it('Should get the markdown url from the first endpoint param', async () => {
 
         await registryWrapper.getProviderParam(
-            signerOne._address,
+            signers[0]._address,
             testProvider.endpoint_params[0]
         )
             .then((markdownParam: String) => {
@@ -326,7 +326,7 @@ describe('Registry Test', () => {
     it('Should get the json url from the second endpoint param', async () => {
 
         await registryWrapper.getProviderParam(
-            signerOne._address,
+            signers[0]._address,
             testProvider.endpoint_params[1]
         )
             .then((jsonParam: String) => {
@@ -340,7 +340,7 @@ describe('Registry Test', () => {
 
     it('Should get all provider params', async () => {
 
-        await registryWrapper.getAllProviderParams(signerOne._address)
+        await registryWrapper.getAllProviderParams(signers[0]._address)
 
             .then((getProviderParams: Array<string>) => {
 
@@ -403,7 +403,7 @@ describe('Registry Test', () => {
     it('Should check if the endpoint and corresponding curve is set', async () => {
 
         await registryWrapper.isEndpointSet(
-            signerOne._address,
+            signers[0]._address,
             testProvider.endpoints[0]
         )
             .then((unset: Boolean) => {
@@ -450,7 +450,7 @@ describe('Registry Test', () => {
 
     it('Should have an empty array of endpoints after clearing', async () => {
 
-        await registryWrapper.getProviderEndpoints(signerOne._address)
+        await registryWrapper.getProviderEndpoints(signers[0]._address)
 
             .then((getEndpoints: Array<string>) => {
 

--- a/test/registrytest.ts
+++ b/test/registrytest.ts
@@ -8,7 +8,6 @@ import {
     HardhatProvider
 }
     from '../Utils/utils';
-import { AnyARecord } from 'node:dns';
 
 const expect = require('chai').expect;
 
@@ -66,11 +65,9 @@ describe('Registry Test', () => {
 
     it('Should initiate provider in zap registry contract', async () => {
 
-        let initProviderTx: any;
-
         try {
 
-            initProviderTx = await registryWrapper.initiateProvider({
+            const initProviderTx: any = await registryWrapper.initiateProvider({
 
                 public_key: testProvider.pubkey,
                 title: testProvider.title
@@ -80,7 +77,7 @@ describe('Registry Test', () => {
                 expect(newProvider).to.be.a('string')
             );
 
-            const initProviderReceipt = await initProviderTx.wait();
+            const initProviderReceipt: any = await initProviderTx.wait();
 
             expect(initProviderReceipt).to.include.keys('events');
 
@@ -88,7 +85,7 @@ describe('Registry Test', () => {
 
             expect(initProviderReceipt.events[0]).to.include.keys('args');
 
-            const args = initProviderReceipt.events[0].args;
+            const args: any = initProviderReceipt.events[0].args;
 
             expect(args).to.include.keys('provider', 'title');
 
@@ -96,17 +93,17 @@ describe('Registry Test', () => {
 
             expect(args.provider).to.equal(signers[0]._address);
 
-            const title = await registryWrapper.getProviderTitle(signers[0]._address);
+            const title: String = await registryWrapper.getProviderTitle(signers[0]._address);
 
             expect(title).to.be.equal(testProvider.title);
 
-            const pubkey = await registryWrapper.getProviderPublicKey(signers[0]._address);
+            const pubkey: Number = await registryWrapper.getProviderPublicKey(signers[0]._address);
 
             expect(pubkey).to.be.equal(testProvider.pubkey);
 
         } catch (err) {
 
-            const initStatus = await registryWrapper.isProviderInitiated(signers[0]._address);
+            const initStatus: Boolean = await registryWrapper.isProviderInitiated(signers[0]._address);
 
             if (initStatus === true) {
 
@@ -122,18 +119,16 @@ describe('Registry Test', () => {
 
     it('Should initiate Provider curve  with 0x0 broker in zap registry contract', async () => {
 
-        let initProviderCurveTx: any;
-
         try {
 
-            initProviderCurveTx = await registryWrapper.initiateProviderCurve({
+            const initProviderCurveTx: any = await registryWrapper.initiateProviderCurve({
 
                 endpoint: testProvider.endpoints[0],
                 term: testProvider.curve.values,
                 broker: testProvider.broker
             });
 
-            const curveReceipt = await initProviderCurveTx.wait();
+            const curveReceipt: any = await initProviderCurveTx.wait();
 
             expect(curveReceipt).to.include.keys('events');
 
@@ -141,7 +136,7 @@ describe('Registry Test', () => {
 
             expect(curveReceipt.events[0]).to.include.keys('args');
 
-            const args = curveReceipt.events[0].args;
+            const args: any = curveReceipt.events[0].args;
 
             expect(args).to.include.keys('provider', 'endpoint', 'curve', 'broker');
 
@@ -149,9 +144,9 @@ describe('Registry Test', () => {
 
             expect(args.provider).to.equal(signers[0]._address);
 
-            const getTxCurve = args.curve.map((num: any) => parseInt(num));
+            const getTxCurve: Array<number> = args.curve.map((num: any) => parseInt(num));
 
-            const testCurve = testProvider.curve.values;
+            const testCurve: Array<number> = testProvider.curve.values;
 
             expect(testProvider.endpoints[0]).to.equal(ethers.utils.parseBytes32String(args.endpoint));
 
@@ -166,211 +161,151 @@ describe('Registry Test', () => {
 
     it('Should set new title', async () => {
 
-        const title = 'NEWTITLE';
+        const title: String = 'NEWTITLE';
 
-        await registryWrapper.setProviderTitle({
+        const setTitleTx: Object = await registryWrapper.setProviderTitle({
             title: title
-        })
-            .then(async (setTitle: Object) => {
+        });
 
-                expect(setTitle).to.be.ok;
+        expect(setTitleTx).to.be.ok;
 
-                const newTitle = await registryWrapper.getProviderTitle(signers[0]._address);
+        const newTitle: String = await registryWrapper.getProviderTitle(signers[0]._address);
 
-                expect(newTitle).to.equal(title);
-            })
-            .catch((err: Object) => {
+        expect(newTitle).to.equal(title);
 
-                return err;
-            })
+        expect(newTitle).to.equal(title);
+
     });
 
     it('Should initiate Provider curve with valid broker address in zap registry contract', async () => {
 
-        try {
+        const initCurveTwoTx: any = await registryWrapper.initiateProviderCurve({
+            endpoint: testProvider.endpoints[1],
+            term: testProvider.curve.values,
+            broker: signers[1]._address,
+        });
 
-            await registryWrapper.initiateProviderCurve({
-                endpoint: testProvider.endpoints[1],
-                term: testProvider.curve.values,
-                broker: signers[1]._address,
-            })
-                .then((initCurveTwoTx: Object) => {
-
-                    expect(initCurveTwoTx).to.be.ok;
-
-                })
-                .catch((err: Object) => {
-
-                    return err;
-                })
-
-        } catch (err) {
-
-            console.log(signers[1]._address + ': ' + 'Provider and Curve is already initiated');
-        }
+        expect(initCurveTwoTx).to.be.ok;
 
     });
 
     it('Should get the provider curve', async () => {
 
-        await registryWrapper.getProviderCurve(
-            signers[1]._address,
+        const getCurve: Array<number> = await registryWrapper.getProviderCurve(
+            signers[0]._address,
             testProvider.endpoints[0]
-        )
-            .then((getCurve: Array<number>) => {
+        );
 
-                expect(getCurve).to.ok;
+        expect(getCurve).to.ok;
 
-                expect(getCurve.values).to.eql(testProvider.curve.values);
-            })
-            .catch((err: Object) => {
-                return err;
-            })
+        expect(getCurve.values).to.eql(testProvider.curve.values);
+
+        expect(getCurve.values).to.eql(testProvider.curve.values);
 
     });
 
     it('Should get endpoint broker', async () => {
 
-        await registryWrapper.getEndpointBroker(
-            signers[1]._address,
+        const getBroker: String = await registryWrapper.getEndpointBroker(
+            signers[0]._address,
             testProvider.endpoints[0]
-        )
-            .then((getBroker: String) => {
+        );
 
-                expect(getBroker).to.be.ok;
-                expect(getBroker).to.be.equal(testProvider.broker);
-            })
-            .catch((err: Object) => {
+        expect(getBroker).to.be.ok;
+        expect(getBroker).to.be.equal(testProvider.broker);
 
-                return err;
-            })
     });
 
     it('Should set endpoint endpointParams in zap registry contract', async () => {
 
-        await registryWrapper.setEndpointParams({
+        const setParamsTx: Object = await registryWrapper.setEndpointParams({
             endpoint: testProvider.endpoints[0],
             endpoint_params: testProvider.endpoint_params,
-        })
-            .then((setParamsTx: Object) => {
-                expect(setParamsTx).to.be.ok
-            })
-            .catch((err: Object) => {
+        });
 
-                return err;
-            })
+        expect(setParamsTx).to.be.ok
+
     });
 
     it('Should get the endpoint params in zap registry contract', async () => {
 
-        await registryWrapper.getEndpointParams({
-            provider: signers[1]._address,
+        const getEndpointParams: Array<string> = await registryWrapper.getEndpointParams({
+            provider: signers[0]._address,
             endpoint: testProvider.endpoints[0]
-        })
-            .then((endpointParams: Array<string>) => {
+        });
 
-                expect(endpointParams).to.be.ok;
-                expect(endpointParams).to.eql(testProvider.endpoint_params);
+        expect(getEndpointParams).to.be.ok;
+        expect(getEndpointParams).to.eql(testProvider.endpoint_params);
 
-            })
-            .catch((err: Object) => {
-                return err;
-            })
     });
 
     it('Should set the markdown url for the first endpoint param ', async () => {
 
-        await registryWrapper.setProviderParameter({
+        const setMdTx: Object = await registryWrapper.setProviderParameter({
             key: testProvider.endpoint_params[0],
             value: testProvider.markdownUrl
-        })
-            .then((mdTx: Object) => {
+        });
 
-                expect(mdTx).to.be.ok;
-            })
-            .catch((err: Object) => {
-                return err;
-            })
+        expect(setMdTx).to.be.ok;
+
     });
 
     it('Should set the json url for the second endpoint param ', async () => {
 
-        await registryWrapper.setProviderParameter({
+        const setJsonTx: Object = await registryWrapper.setProviderParameter({
             key: testProvider.endpoint_params[1],
             value: testProvider.jsonUrl
-        })
-            .then((jsonTx: Object) => {
+        });
 
-                expect(jsonTx).to.be.ok;
-            })
-            .catch((err: Object) => {
+        expect(setJsonTx).to.be.ok;
 
-                return err;
-            })
     });
 
     it('Should get the markdown url from the first endpoint param', async () => {
 
-        await registryWrapper.getProviderParam(
+        const getMd: String = await registryWrapper.getProviderParam(
             signers[0]._address,
             testProvider.endpoint_params[0]
-        )
-            .then((markdownParam: String) => {
-                expect(markdownParam).to.equal(testProvider.markdownUrl);
-            })
-            .catch((err: Object) => {
-                return err;
-            })
+        );
+
+        expect(getMd).to.equal(testProvider.markdownUrl);
+
     });
 
     it('Should get the json url from the second endpoint param', async () => {
 
-        await registryWrapper.getProviderParam(
+        const getJson: String = await registryWrapper.getProviderParam(
             signers[0]._address,
             testProvider.endpoint_params[1]
-        )
-            .then((jsonParam: String) => {
+        );
 
-                expect(jsonParam).to.equal(testProvider.jsonUrl);
-            })
-            .catch((err: Object) => {
-                return err;
-            })
+        expect(getJson).to.equal(testProvider.jsonUrl);
+
     });
 
     it('Should get all provider params', async () => {
 
-        await registryWrapper.getAllProviderParams(signers[0]._address)
+        const getAllParams: Array<string> = await registryWrapper.getAllProviderParams(
+            signers[0]._address
+        );
 
-            .then((getProviderParams: Array<string>) => {
+        expect(getAllParams).to.eql(testProvider.endpoint_params);
 
-                expect(getProviderParams).to.eql(testProvider.endpoint_params);
-
-            })
-            .catch((err: Object) => {
-
-                return err;
-            })
     });
 
     it('Should be able to get all providers', async () => {
 
-        await registryWrapper.getAllProviders()
+        const getProviders: Array<string> = await registryWrapper.getAllProviders();
 
-            .then((getProviders: Array<string>) => {
+        expect(getProviders).to.be.ok;
 
-                expect(getProviders).to.be.ok;
-            })
-            .catch((err: Object) => {
-                return err;
-            })
     });
 
     it('Should get provider address by index', async () => {
 
-        const providers = [];
+        const providers: Array<string> = [];
 
-        const allProviders = await registryWrapper.getAllProviders();
+        const allProviders: String = await registryWrapper.getAllProviders();
 
         expect(allProviders).to.be.ok;
 
@@ -386,9 +321,9 @@ describe('Registry Test', () => {
 
     it('Should check if all providers are initiated', async () => {
 
-        const initStatus = [];
+        const initStatus: Array<boolean> = [];
 
-        const allProviders = await registryWrapper.getAllProviders()
+        const allProviders: Array<string> = await registryWrapper.getAllProviders();
 
         for (let i = 0; i < allProviders.length; i++) {
 
@@ -402,65 +337,58 @@ describe('Registry Test', () => {
 
     it('Should check if the endpoint and corresponding curve is set', async () => {
 
-        await registryWrapper.isEndpointSet(
+        const curveStatus: Boolean = await registryWrapper.isEndpointSet(
             signers[0]._address,
             testProvider.endpoints[0]
-        )
-            .then((unset: Boolean) => {
-                expect(unset).to.be.true;
-            })
-            .catch((err: Object) => {
-                return err;
-            })
+        );
+
+        expect(curveStatus).to.be.true;
 
     });
 
     it('Should clear the first endpoint', async () => {
 
-        await registryWrapper.clearEndpoint({
+        const clearTx: Object = await registryWrapper.clearEndpoint({
 
             endpoint: testProvider.endpoints[0]
-        })
-            .then((clearEndpointTx: Object) => {
+        });
 
-                expect(clearEndpointTx).to.be.ok;
-            })
-            .catch((err: Object) => {
+        expect(clearTx).to.be.ok;
 
-                return err;
-            })
     });
 
     it('Should clear the last endpoint', async () => {
 
-        await registryWrapper.clearEndpoint({
+        const clearTx: Object = await registryWrapper.clearEndpoint({
 
             endpoint: testProvider.endpoints[1]
-        })
-            .then((clearEndpointTx: Object) => {
+        });
 
-                expect(clearEndpointTx).to.be.ok;
+        expect(clearTx).to.be.ok;
 
-            })
-            .catch((err: Object) => {
-
-                return err;
-            })
     });
 
     it('Should have an empty array of endpoints after clearing', async () => {
 
-        await registryWrapper.getProviderEndpoints(signers[0]._address)
+        const getEndpoints: Array<string> = await registryWrapper.getProviderEndpoints(signers[0]._address);
 
-            .then((getEndpoints: Array<string>) => {
+        expect(getEndpoints).to.be.ok;
 
-                expect(getEndpoints).to.be.ok;
-                expect(getEndpoints.length).to.equal(0);
-            })
-            .catch((err: Object) => {
+        expect(getEndpoints.length).to.equal(0);
 
-                return err;
-            })
-    })
+    });
+
+    it('Should initiate Provider curve after clearing', async () => {
+
+        const initProviderCurveTx: Object = await registryWrapper.initiateProviderCurve({
+
+            endpoint: testProvider.endpoints[0],
+            term: testProvider.curve.values,
+            broker: testProvider.broker
+        });
+
+        expect(initProviderCurveTx).to.be.ok;
+
+    });
 
 })

--- a/test/zaptokentest.ts
+++ b/test/zaptokentest.ts
@@ -42,6 +42,12 @@ describe('ZapToken Test', () => {
 
     });
 
+    after(() => {
+
+        console.log('Done running ZapToken tests');
+
+    });
+
     it('Should initiate wrapper', async () => {
 
         zapTokenWrapper = new ZapToken(options)

--- a/test/zaptokentest.ts
+++ b/test/zaptokentest.ts
@@ -15,10 +15,8 @@ describe('ZapToken Test', () => {
 
     let hardhatHttpProvider: any;
     let hardhatAccounts: any;
-    let signerOne: any
-    let signerTwo: any
-    let signerThree: any
-
+    let signerOne: any;
+    let signerTwo: any;
 
     let accounts: Array<string> = [],
         HardhatServer: any,
@@ -41,8 +39,6 @@ describe('ZapToken Test', () => {
         signerOne = await hardhatHttpProvider.getSigner(hardhatAccounts[0]);
 
         signerTwo = await hardhatHttpProvider.getSigner(hardhatAccounts[1]);
-
-        signerThree = await hardhatHttpProvider.getSigner(hardhatAccounts[2]);
 
     });
 
@@ -115,6 +111,44 @@ describe('ZapToken Test', () => {
                 expect(allocateTx).to.be.ok;
                 expect(afterAllocation).to.be.equal(allocateAmount + beforeAllocation);
 
+            })
+            .catch((err: Object) => {
+
+                return err;
+            })
+    });
+
+    it('Should make transfer to another account', async () => {
+
+        const beforeTransfer = await zapTokenWrapper.balanceOf(signerTwo._address);
+
+        await zapTokenWrapper.send({
+            to: signerTwo,
+            amount: allocateAmount,
+        })
+            .then(async (transferTx: Object) => {
+
+                const afterTransfer = await zapTokenWrapper.balanceOf(signerTwo._address);
+
+                expect(transferTx).to.be.ok;
+                expect(afterTransfer).to.be.ok;
+                expect(afterTransfer).to.be.equal(allocateAmount + beforeTransfer);
+
+            })
+            .catch((err: Object) => {
+
+                return err;
+            })
+    });
+
+    it('Should approve to transfer from one to the another account', async () => {
+
+        await zapTokenWrapper.approve({
+            to: signerTwo._address,
+            amount: allocateAmount,
+        })
+            .then((approveTx: Object) => {
+                expect(approveTx).to.be.ok;
             })
             .catch((err: Object) => {
 

--- a/test/zaptokentest.ts
+++ b/test/zaptokentest.ts
@@ -15,10 +15,8 @@ describe('ZapToken Test', () => {
 
     let hardhatHttpProvider: any;
     let hardhatAccounts: any;
-    let signerOne: any;
-    let signerTwo: any;
 
-    let accounts: Array<string> = [],
+    let signers: Array<any> = [],
         HardhatServer: any,
         zapTokenWrapper: any,
         testProvider = testZapProvider,
@@ -36,9 +34,10 @@ describe('ZapToken Test', () => {
 
         hardhatAccounts = await hardhatHttpProvider.listAccounts();
 
-        signerOne = await hardhatHttpProvider.getSigner(hardhatAccounts[0]);
+        for (let i = 0; i < hardhatAccounts.length; i++) {
 
-        signerTwo = await hardhatHttpProvider.getSigner(hardhatAccounts[1]);
+            signers.push(await hardhatHttpProvider.getSigner(hardhatAccounts[i]));
+        }
 
     });
 
@@ -77,7 +76,7 @@ describe('ZapToken Test', () => {
 
             .then((owner: String) => {
 
-                expect(owner).to.be.equal(signerOne._address);
+                expect(owner).to.be.equal(signers[0]._address);
 
             })
             .catch((err: Object) => {
@@ -88,7 +87,7 @@ describe('ZapToken Test', () => {
 
     it('Should get balance of zapToken from wrapper', async () => {
 
-        await zapTokenWrapper.balanceOf(signerOne._address)
+        await zapTokenWrapper.balanceOf(signers[0]._address)
 
             .then((balance: Number) => {
 
@@ -103,15 +102,15 @@ describe('ZapToken Test', () => {
 
     it('Should update balance, and get updated balance of zap token', async () => {
 
-        const beforeAllocation = await zapTokenWrapper.balanceOf(signerTwo._address);
+        const beforeAllocation = await zapTokenWrapper.balanceOf(signers[1]._address);
 
         await zapTokenWrapper.allocate({
-            to: signerTwo._address,
+            to: signers[1]._address,
             amount: allocateAmount
         })
             .then(async (allocateTx: Object) => {
 
-                const afterAllocation = await zapTokenWrapper.balanceOf(signerTwo._address);
+                const afterAllocation = await zapTokenWrapper.balanceOf(signers[1]._address);
                 expect(beforeAllocation).to.be.ok;
                 expect(afterAllocation).to.be.ok;
                 expect(allocateTx).to.be.ok;
@@ -126,15 +125,15 @@ describe('ZapToken Test', () => {
 
     it('Should make transfer to another account', async () => {
 
-        const beforeTransfer = await zapTokenWrapper.balanceOf(signerTwo._address);
+        const beforeTransfer = await zapTokenWrapper.balanceOf(signers[1]._address);
 
         await zapTokenWrapper.send({
-            to: signerTwo,
+            to: signers[1]._address,
             amount: allocateAmount,
         })
             .then(async (transferTx: Object) => {
 
-                const afterTransfer = await zapTokenWrapper.balanceOf(signerTwo._address);
+                const afterTransfer = await zapTokenWrapper.balanceOf(signers[1]._address);
 
                 expect(transferTx).to.be.ok;
                 expect(afterTransfer).to.be.ok;
@@ -150,7 +149,7 @@ describe('ZapToken Test', () => {
     it('Should approve to transfer from one to the another account', async () => {
 
         await zapTokenWrapper.approve({
-            to: signerTwo._address,
+            to: signers[1]._address,
             amount: allocateAmount,
         })
             .then((approveTx: Object) => {

--- a/test/zaptokentest.ts
+++ b/test/zaptokentest.ts
@@ -72,6 +72,7 @@ describe('ZapToken Test', () => {
     it('Should get zapToken owner', async () => {
 
         await zapTokenWrapper.getContractOwner()
+
             .then((owner: String) => {
 
                 expect(owner).to.be.equal(signerOne._address);
@@ -83,12 +84,21 @@ describe('ZapToken Test', () => {
             })
     });
 
-    // it('Should get balance of zapToken from wrapper', async () => {
+    it('Should get balance of zapToken from wrapper', async () => {
 
-    //     const balance = await zapTokenWrapper.balanceOf(signerOne._address);
+        await zapTokenWrapper.balanceOf(signerOne._address)
 
-    //     expect(balance).to.be.ok;
-    // });
+            .then((balance: Number) => {
+
+                expect(balance).to.be.ok;
+                expect(balance).to.be.gt(0);
+            })
+            .catch((err: Object) => {
+
+                return err;
+            })
+
+    });
 
 
 });

--- a/test/zaptokentest.ts
+++ b/test/zaptokentest.ts
@@ -65,27 +65,30 @@ describe('ZapToken Test', () => {
             coordinator: zapTokenWrapper.coordinator.address
         });
 
-        //     zapTokenOwner = await zapTokenWrapper.getContractOwner();
-
-        //     expect(zapTokenWrapper).to.be.ok;
-
-        // });
-
-        // it('Should get zapToken owner', async () => {
-
-        //     const owner = await zapTokenWrapper.getContractOwner();
-
-        //     expect(owner).to.be.equal(signerOne._address);
-
-        // });
-
-        // it('Should get balance of zapToken from wrapper', async () => {
-
-        //     const balance = await zapTokenWrapper.balanceOf(signerOne._address);
-
-        //     expect(balance).to.be.ok;
-        // });
-
+        expect(zapTokenWrapper).to.be.ok;
 
     });
-})
+
+    it('Should get zapToken owner', async () => {
+
+        await zapTokenWrapper.getContractOwner()
+            .then((owner: String) => {
+
+                expect(owner).to.be.equal(signerOne._address);
+
+            })
+            .catch((err: Object) => {
+
+                return err;
+            })
+    });
+
+    // it('Should get balance of zapToken from wrapper', async () => {
+
+    //     const balance = await zapTokenWrapper.balanceOf(signerOne._address);
+
+    //     expect(balance).to.be.ok;
+    // });
+
+
+});

--- a/test/zaptokentest.ts
+++ b/test/zaptokentest.ts
@@ -71,20 +71,20 @@ describe('ZapToken Test', () => {
 
     // });
 
-    it('Should get zapToken owner', async () => {
+    // it('Should get zapToken owner', async () => {
 
-        const owner = await zapTokenWrapper.getContractOwner();
+    //     const owner = await zapTokenWrapper.getContractOwner();
 
-        expect(owner).to.be.equal(signerOne._address);
+    //     expect(owner).to.be.equal(signerOne._address);
 
-    });
+    // });
 
-    it('Should get balance of zapToken from wrapper', async () => {
+    // it('Should get balance of zapToken from wrapper', async () => {
 
-        const balance = await zapTokenWrapper.balanceOf(signerOne._address);
+    //     const balance = await zapTokenWrapper.balanceOf(signerOne._address);
 
-        expect(balance).to.be.ok;
-    });
+    //     expect(balance).to.be.ok;
+    // });
 
 
 });

--- a/test/zaptokentest.ts
+++ b/test/zaptokentest.ts
@@ -44,7 +44,6 @@ describe('ZapToken Test', () => {
 
         signerThree = await hardhatHttpProvider.getSigner(hardhatAccounts[2]);
 
-
     });
 
     it('Should initiate wrapper', async () => {
@@ -53,39 +52,40 @@ describe('ZapToken Test', () => {
 
         zapTokenOwner = await zapTokenWrapper.getContractOwner();
 
+        expect(zapTokenOwner).to.be.ok;
         expect(zapTokenWrapper).to.be.ok;
 
     });
 
-    // it('Should initiate wrapper with coordinator ', async () => {
+    it('Should initiate wrapper with coordinator ', async () => {
 
-    //     zapTokenWrapper = new ZapToken({
-    //         networkId: HardhatServerOptions.network_id,
-    //         networkProvider: HardhatProvider,
-    //         coordinator: zapTokenWrapper.coordinator.address
-    //     });
+        zapTokenWrapper = new ZapToken({
+            networkId: HardhatServerOptions.network_id,
+            networkProvider: HardhatProvider,
+            coordinator: zapTokenWrapper.coordinator.address
+        });
 
-    //     zapTokenOwner = await zapTokenWrapper.getContractOwner();
+        //     zapTokenOwner = await zapTokenWrapper.getContractOwner();
 
-    //     expect(zapTokenWrapper).to.be.ok;
+        //     expect(zapTokenWrapper).to.be.ok;
 
-    // });
+        // });
 
-    // it('Should get zapToken owner', async () => {
+        // it('Should get zapToken owner', async () => {
 
-    //     const owner = await zapTokenWrapper.getContractOwner();
+        //     const owner = await zapTokenWrapper.getContractOwner();
 
-    //     expect(owner).to.be.equal(signerOne._address);
+        //     expect(owner).to.be.equal(signerOne._address);
 
-    // });
+        // });
 
-    // it('Should get balance of zapToken from wrapper', async () => {
+        // it('Should get balance of zapToken from wrapper', async () => {
 
-    //     const balance = await zapTokenWrapper.balanceOf(signerOne._address);
+        //     const balance = await zapTokenWrapper.balanceOf(signerOne._address);
 
-    //     expect(balance).to.be.ok;
-    // });
+        //     expect(balance).to.be.ok;
+        // });
 
 
-});
-
+    });
+})

--- a/test/zaptokentest.ts
+++ b/test/zaptokentest.ts
@@ -26,7 +26,7 @@ describe('ZapToken Test', () => {
             networkProvider: HardhatProvider
         };
 
-    const allocateAmount = '1000';
+    const allocateAmount: any = 1000;
 
     beforeEach(async () => {
 
@@ -72,93 +72,70 @@ describe('ZapToken Test', () => {
 
     it('Should get zapToken owner', async () => {
 
-        await zapTokenWrapper.getContractOwner()
+        const owner: String = await zapTokenWrapper.getContractOwner();
 
-            .then((owner: String) => {
+        expect(owner).to.be.equal(signers[0]._address);
 
-                expect(owner).to.be.equal(signers[0]._address);
-
-            })
-            .catch((err: Object) => {
-
-                return err;
-            })
     });
 
     it('Should get balance of zapToken from wrapper', async () => {
 
-        await zapTokenWrapper.balanceOf(signers[0]._address)
+        const getBalance: Number = await zapTokenWrapper.balanceOf(signers[0]._address)
 
-            .then((balance: Number) => {
+        expect(getBalance).to.be.ok;
+        expect(getBalance).to.be.gt(0);
 
-                expect(balance).to.be.ok;
-                expect(balance).to.be.gt(0);
-            })
-            .catch((err: Object) => {
-
-                return err;
-            })
     });
 
     it('Should update balance, and get updated balance of zap token', async () => {
 
-        const beforeAllocation = await zapTokenWrapper.balanceOf(signers[1]._address);
+        const beforeAllocation: any = await zapTokenWrapper.balanceOf(signers[1]._address);
 
-        await zapTokenWrapper.allocate({
+        const allocateTx: Object = await zapTokenWrapper.allocate({
             to: signers[1]._address,
             amount: allocateAmount
-        })
-            .then(async (allocateTx: Object) => {
+        });
 
-                const afterAllocation = await zapTokenWrapper.balanceOf(signers[1]._address);
-                expect(beforeAllocation).to.be.ok;
-                expect(afterAllocation).to.be.ok;
-                expect(allocateTx).to.be.ok;
-                expect(afterAllocation).to.be.equal(allocateAmount + beforeAllocation);
+        const afterAllocation: any = await zapTokenWrapper.balanceOf(signers[1]._address);
 
-            })
-            .catch((err: Object) => {
+        expect(beforeAllocation).to.be.ok;
 
-                return err;
-            })
+        expect(afterAllocation).to.be.ok;
+
+        expect(allocateTx).to.be.ok;
+
+        expect(afterAllocation).to.be.equal(beforeAllocation + allocateAmount);
+
     });
 
     it('Should make transfer to another account', async () => {
 
-        const beforeTransfer = await zapTokenWrapper.balanceOf(signers[1]._address);
+        const beforeTransfer: any = await zapTokenWrapper.balanceOf(signers[1]._address);
 
-        await zapTokenWrapper.send({
+        const transferTx: Object = await zapTokenWrapper.send({
             to: signers[1]._address,
             amount: allocateAmount,
         })
-            .then(async (transferTx: Object) => {
 
-                const afterTransfer = await zapTokenWrapper.balanceOf(signers[1]._address);
+        const afterTransfer: any = await zapTokenWrapper.balanceOf(signers[1]._address);
 
-                expect(transferTx).to.be.ok;
-                expect(afterTransfer).to.be.ok;
-                expect(afterTransfer).to.be.equal(allocateAmount + beforeTransfer);
+        expect(transferTx).to.be.ok;
 
-            })
-            .catch((err: Object) => {
+        expect(afterTransfer).to.be.ok;
 
-                return err;
-            })
+        expect(afterTransfer).to.be.equal(allocateAmount + beforeTransfer);
+
     });
 
     it('Should approve to transfer from one to the another account', async () => {
 
-        await zapTokenWrapper.approve({
+        const approveTx: Object = await zapTokenWrapper.approve({
             to: signers[1]._address,
             amount: allocateAmount,
         })
-            .then((approveTx: Object) => {
-                expect(approveTx).to.be.ok;
-            })
-            .catch((err: Object) => {
 
-                return err;
-            })
+        expect(approveTx).to.be.ok;
+
     });
 
 });

--- a/test/zaptokentest.ts
+++ b/test/zaptokentest.ts
@@ -97,8 +97,29 @@ describe('ZapToken Test', () => {
 
                 return err;
             })
-
     });
 
+    it('Should update balance, and get updated balance of zap token', async () => {
+
+        const beforeAllocation = await zapTokenWrapper.balanceOf(signerTwo._address);
+
+        await zapTokenWrapper.allocate({
+            to: signerTwo._address,
+            amount: allocateAmount
+        })
+            .then(async (allocateTx: Object) => {
+
+                const afterAllocation = await zapTokenWrapper.balanceOf(signerTwo._address);
+                expect(beforeAllocation).to.be.ok;
+                expect(afterAllocation).to.be.ok;
+                expect(allocateTx).to.be.ok;
+                expect(afterAllocation).to.be.equal(allocateAmount + beforeAllocation);
+
+            })
+            .catch((err: Object) => {
+
+                return err;
+            })
+    });
 
 });


### PR DESCRIPTION
## Summary
Closes #18 
Enhances #21 

## Implementation
-  Converted the ZapToken class from Web3.js to Ethers.js
- The ZapToken class can be instantiated with Ethers.js
- Converted the ZapToken tests to use Ethers.js and reference the ZapToken functions to pass after running the Hardhat node and npm test
- Changed how the Hardhat signers were being stored and accessed for the ZapToken and Registry tests
- Added an initiateProviderCurve function at the end of the Registry test so a curve can exist after testing the clearEndpoint function

## Files
```ZapToken\zaptoken.ts ```
```test\zaptokentest.ts ```
```test\registrytest.ts ```

## Branches
```registry-refactor```
```zaptoken-refactor```
```bugfix-zaptoken+registry-tests```

## Visual Preview
While the Hardhat node is running and the contracts are deployed the tests will start with npm test
![Screenshot (218)](https://user-images.githubusercontent.com/42893948/111365993-5c1ca000-8669-11eb-9cfc-2e6c87e82746.png)

